### PR TITLE
accept multiple arguments to match the rxjs operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-const startWith = value => inputSource => (start, outputSink) => {
+const startWith = (...xs) => inputSource => (start, outputSink) => {
   if (start !== 0) return;
   let inputTalkback;
   inputSource(0, (it,id) => {
@@ -8,7 +8,7 @@ const startWith = value => inputSource => (start, outputSink) => {
       outputSink(0, ot => {
         if (ot === 2) inputTalkback(ot);
       });
-      outputSink(1, value);
+      xs.forEach(x => outputSink(1, x));
     } else {
       outputSink(it, id);
     }

--- a/test.js
+++ b/test.js
@@ -63,3 +63,27 @@ test('it supports iterables', t => {
 
   t.end();
 });
+
+test('it supports multiple arguments', t => {
+  let history = [];
+  const report = (name,dir,t,d) => t !== 0 && d !== undefined && history.push([name,dir,t,d]);
+
+  const source = makeMockCallbag('source', true);
+  const seedWithFoo = startWith('foo', 'bar', 'baz');
+  const sink = makeMockCallbag('sink', report);
+
+  seedWithFoo(source)(0, sink);
+
+  source.emit(1, 'qu');
+  source.emit(2, 'error');
+
+  t.deepEqual(history, [
+    ['sink', 'body', 1, 'foo'],
+    ['sink', 'body', 1, 'bar'],
+    ['sink', 'body', 1, 'baz'],
+    ['sink', 'body', 1, 'qu'],
+    ['sink', 'body', 2, 'error'],
+  ], 'sink gets seed and subsequent data');
+
+  t.end();
+});


### PR DESCRIPTION
:wave: feel free to close this if it doesn't seem worthwhile 

just thought it might be helpful to have the API of the operator match `rxjs` more closely for the benefit of users new to callbags?

see example 3 [here](https://www.learnrxjs.io/operators/combination/startwith.html)